### PR TITLE
Add --use abort=wasi_abort to AssemblyScript package.json

### DIFF
--- a/templates/assembly-script/package.json
+++ b/templates/assembly-script/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "A WASM hello-world",
   "scripts": {
-    "build:untouched": "asc assembly/index.ts --target debug",
-    "build:optimized": "asc assembly/index.ts --target release",
+    "build:untouched": "asc assembly/index.ts --target debug --use abort=wasi_abort",
+    "build:optimized": "asc assembly/index.ts --target release --use abort=wasi_abort",
     "build": "npm run build:untouched && npm run build:optimized"
   },
   "author": "<%= authorName %>",


### PR DESCRIPTION
This commit adds `--use abort=wasi_abort` to 
the build definitions for AssemblyScript, meaning 
modules built this way do not need any additional 
imports defined before starting them.

In the current state, runtimes trying to start a module
would need to define the `abort` function.